### PR TITLE
Use Invoke-WebRequest instead of curl

### DIFF
--- a/Invoke-JsonRequest.psm1
+++ b/Invoke-JsonRequest.psm1
@@ -1,5 +1,5 @@
 ﻿function Invoke-JsonRequest ([string]$Uri)
 {
-    $response = curl $Uri
+    $response = Invoke-WebRequest $Uri
     ConvertFrom-Json $response.Content
 }


### PR DESCRIPTION
`curl` is a PowerShell alias for `Invoke-WebRequest`. There is [currently a discussion](https://github.com/PowerShell/PowerShell/pull/1901) about removing those aliases.
